### PR TITLE
Add an Elasticsearch component

### DIFF
--- a/README.org
+++ b/README.org
@@ -13,6 +13,7 @@
 - [[http://clojurerabbitmq.info/][Langohr]] (RabbitMQ client)
 - [[https://github.com/danielsz/etsy-clojure-api][Etsy]] (Etsy client)
 - [[http://docs.caudate.me/hara/#haraiowatch][hara.io.watch]] (File watcher)
+- [[https://www.elastic.co/][Elasticsearch]] (Elasticsearch full-text search engine)
 
 ** Motivation
 A good REPL experience is a prerogative of Lisp languages. [[https://github.com/stuartsierra/reloaded][Reloaded]] components enable this goodness in Clojureland. Since they require an amount of setup, the first steps when starting a new project are generally devoted to infrastructure. My first attempt to tackle the boilerplate was a Leiningen [[https://github.com/danielsz/back-end-template][template]]. The problem is that Leiningen templates are hard to maintain and difficult to retrofit on existing projects. I was finding myself repeatedly updating the template for future use. Then it dawned on me that a library would better fit the bill. And so *system* came to light. It’s now the first dependency I add to any project, allowing me to focus from the get-go on the substance of my application.

--- a/project.clj
+++ b/project.clj
@@ -18,6 +18,21 @@
                                   [com.taoensso/sente "1.4.1"]
                                   [org.danielsz/etsy "0.1.2" ]
                                   [http-kit "2.1.19"]
+                                  [org.elasticsearch/elasticsearch "1.4.5"
+                                   :exclusions [org.antlr/antlr-runtime
+                                                org.apache.lucene/lucene-analyzers-common
+                                                org.apache.lucene/lucene-grouping
+                                                org.apache.lucene/lucene-highlighter
+                                                org.apache.lucene/lucene-join
+                                                org.apache.lucene/lucene-memory
+                                                org.apache.lucene/lucene-misc
+                                                org.apache.lucene/lucene-queries
+                                                org.apache.lucene/lucene-queryparser
+                                                org.apache.lucene/lucene-sandbox
+                                                org.apache.lucene/lucene-spatial
+                                                org.apache.lucene/lucene-suggest
+                                                org.ow2.asm/asm
+                                                org.ow2.asm/asm-commons]]
                                   [aleph "0.4.0-alpha9"]]}}
   :scm {:name "git"
         :url "https://github.com/danielsz/system"})

--- a/src/system/components/elasticsearch.clj
+++ b/src/system/components/elasticsearch.clj
@@ -1,0 +1,26 @@
+(ns system.components.elasticsearch
+  (:require [com.stuartsierra.component :as component])
+  (:import [org.elasticsearch.client.transport TransportClient]
+           [org.elasticsearch.common.transport InetSocketTransportAddress]
+           [org.elasticsearch.common.settings ImmutableSettings]))
+
+(defrecord Elasticsearch [addresses settings client]
+  component/Lifecycle
+  (start [component]
+    (let [builder (.. (ImmutableSettings/settingsBuilder)
+                      (put ^java.util.Map settings))
+          client (doto (TransportClient. builder)
+                   (.addTransportAddresses (into-array addresses)))]
+      (assoc component :client client)))
+  (stop [component]
+    (when client
+      (.close ^TransportClient client))
+    (assoc component :client nil)))
+
+(defn new-elasticsearch-db
+  ([addresses]
+    (new-elasticsearch-db addresses {}))
+  ([addresses settings]
+    (map->Elasticsearch {:addresses (for [[^String host ^int port] addresses]
+                                      (InetSocketTransportAddress. host port))
+                         :settings settings})))

--- a/test/system/components/elasticsearch_test.clj
+++ b/test/system/components/elasticsearch_test.clj
@@ -1,0 +1,17 @@
+(ns system.components.elasticsearch-test
+  (:require [system.components.elasticsearch :refer [new-elasticsearch-db]]
+            [com.stuartsierra.component :as component]
+            [clojure.test :refer [deftest is]])
+  (:import [org.elasticsearch.action.search SearchRequest]))
+
+(deftest test-elasticsearch
+  (let [elasticsearch-db (component/start
+                           (new-elasticsearch-db
+                             [["localhost" 9300]]
+                             {"cluster.name" "elasticsearch"}))]
+    (try
+      (is @(.search (:client elasticsearch-db)
+                    (SearchRequest. (make-array String 0))))
+      (is (nil? (:client (component/stop elasticsearch-db))))
+      (finally
+        (component/stop elasticsearch-db)))))


### PR DESCRIPTION
Connections established with this component can be used both with
Elasticsearch Java API as well as ClojureWerkz's Elastisch wrapper.

The dependency list in project.clj is trimmed to a minimal subset
necessary to open a connection and execute a query.

Tests expect a local Elasticsearch instance listening on port 9300.