### PR TITLE
destroy-fn of app component

### DIFF
--- a/src/system/components/app.clj
+++ b/src/system/components/app.clj
@@ -2,13 +2,19 @@
   (:require
    [com.stuartsierra.component :as component]))
 
-(defrecord App [app app-fn init-fn db]
+(defrecord App [app app-fn init-fn destroy-fn db]
   component/Lifecycle
   (start [this]
     (when init-fn (init-fn db))
     (assoc this :app (app-fn db)))
   (stop [this]
+    (when destroy-fn (destroy-fn db))
     this))
 
-(defn new-app [app-fn init-fn]
-  (map->App {:app-fn app-fn :init-fn init-fn}))
+(defn new-app
+  ([app-fn]
+    (map->App {:app-fn app-fn}))
+  ([app-fn init-fn]
+    (map->App {:app-fn app-fn :init-fn init-fn}))
+  ([app-fn init-fn destroy-fn]
+    (map->App {:app-fn app-fn :init-fn init-fn :destroy-fn destroy-fn})))


### PR DESCRIPTION
I think it can be usefull to be able to provide a component stop callback and to be a symetric counterpart of the init-fn. Also the constructor without start/stop callbacks can be usefull.