### PR TITLE
added immutant :host "0.0.0.0" binding

### DIFF
--- a/src/system/components/immutant_web.clj
+++ b/src/system/components/immutant_web.clj
@@ -9,7 +9,7 @@
                     fn? handler
                     var? handler
                     (:app handler))
-          server (run handler {:port port})]
+          server (run handler {:host "0.0.0.0" :port port})]
       (assoc component :server server)))
   (stop [component]
     (when server


### PR DESCRIPTION
Hello @danielsz,

I have just found this issue during development:
By default immutant is available only on localhost and not accessible from outside network.

I think it is desirable for a webserver to be accessible from other machines... :)

Regards!