### PR TITLE
Release datomic connection

### DIFF
--- a/src/system/components/datomic.clj
+++ b/src/system/components/datomic.clj
@@ -9,6 +9,7 @@
           conn (d/connect uri)]
       (assoc component :conn conn)))
   (stop [component]
+    (when conn (d/release conn))
     (assoc component :conn nil)))
 
 (defn new-datomic-db [uri]


### PR DESCRIPTION
When running datomic pro connections from Peers is a precious resource. If the connection is not cleaned up properly other Peers might get refused access to the transactor.