### PR TITLE
Filtering by regex and support for .cljc files.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [reloaded.repl "0.1.0"]
+                 [org.clojure/tools.namespace "0.2.11"]
                  [ns-tracker "0.3.0"]
                  [com.stuartsierra/component "0.2.3"]]
   :profiles {:dev {:dependencies [[org.clojure/tools.nrepl "0.2.11"]

--- a/src/system/boot.clj
+++ b/src/system/boot.clj
@@ -21,7 +21,7 @@
 (core/deftask system [s sys SYS code "The system var."
                       a auto-start bool "Auto-starts the system."
                       r hot-reload bool "Enables hot-reloading."
-                      f files FILES [str] "A vector of filenames. Restricts hot-reloading to that set."
+                      f files FILES #{str} "A set of filenames. Restricts hot-reloading to that set."
                       x regexes REGEXES #{regex} "A set of regular expressions. Restricts hot-reloading to files matching any regular expression in that set."]
   (let [fs-prev-state (atom nil)
         dirs (core/get-env :directories)


### PR DESCRIPTION
Took a while, but I've finally learned learned from @weavejester how to solve the `ns-tracker` issue and found time to do that and implement regex filtering; sorry for the wait. `system.boot/system` should now reload with `.cljc` files now as well.

I've also changed the `files` option to us a set as well - I've isolated that to a separate commit in case this would be a breaking change, so you could cherry-pick around it, but it seems boot (running 2.5.5 currently) accepts vectors in place of sets as well.