### PR TITLE
add basic validation to immutant-web

### DIFF
--- a/src/system/components/immutant_web.clj
+++ b/src/system/components/immutant_web.clj
@@ -1,5 +1,5 @@
 (ns system.components.immutant-web
-  (:require [system.util :as util]
+  (:require [schema.core :as s]
             [com.stuartsierra.component :as component]
             [immutant.web :refer [run stop]]))
 
@@ -14,8 +14,13 @@
       (stop server)
       component)))
 
-(def allowed-opts
-  [:host :port :path :virtual-host :dispatch? :servlet-name])
+(def Options
+  {(s/optional-key :host) s/Str
+   (s/optional-key :port) (s/both s/Int (s/pred pos?))
+   (s/optional-key :path) s/Str
+   (s/optional-key :virtual-host) s/Str
+   (s/optional-key :dispatch?) s/Bool
+   (s/optional-key :servlet-name) s/Str})
 
 (defn new-web-server
   ([port]
@@ -23,7 +28,6 @@
   ([port handler]
    (new-web-server port handler {}))
   ([port handler options]
-   (util/assert-options! "immutant-web" options allowed-opts)
-   (map->WebServer {:options (merge {:host "0.0.0.0" :port port}
-                                    options)
+   (map->WebServer {:options (s/validate Options (merge {:host "0.0.0.0" :port port}
+                                               options))
                     :handler handler})))

--- a/test/system/components/immutant_web_test.clj
+++ b/test/system/components/immutant_web_test.clj
@@ -14,3 +14,9 @@
   (alter-var-root #'http-server component/start)
   (is (:server http-server) "HTTP server has been added to component")
   (alter-var-root #'http-server component/stop))
+
+(deftest http-server-illegal-port-throws
+  (is (thrown? RuntimeException (new-web-server -1 handler))))
+
+(deftest http-server-illegal-dispatch-option-throws
+  (is (thrown? RuntimeException (new-web-server 8080 handler {:dispatch? "bob"}))))


### PR DESCRIPTION
Same deal as last, just working through the components with util assertions switching to basic schema validation.

Noticed this article while I was looking around though, thought it might be interesting if you hadn't already seen it https://blog.juxt.pro/posts/component-meet-schema.html