### PR TITLE
Added validation for jetty component

### DIFF
--- a/src/system/components/jetty.clj
+++ b/src/system/components/jetty.clj
@@ -1,5 +1,5 @@
 (ns system.components.jetty
-  (:require [system.util :as util]
+  (:require [schema.core :as s]
             [com.stuartsierra.component :as component]
             [ring.adapter.jetty :refer [run-jetty]]))
 
@@ -14,26 +14,29 @@
       (.stop server)
       component)))
 
-(def allowed-opts
-  [:configurator
-   :port
-   :host
-   :join?
-   :daemon?
-   :ssl?
-   :ssl-port
-   :keystore
-   :key-password
-   :truststore
-   :trust-password
-   :max-threads
-   :min-threads
-   :max-idle-time
-   :client-auth
-   :send-date-header?
-   :output-buffer-size
-   :request-header-size
-   :response-header-size])
+(def pos-int (s/both s/Int (s/pred pos?)))
+(def any-port (s/both s/Int (s/pred #(<= 0 % 65535))))
+
+(def Options
+  {(s/optional-key :configurator) s/Any
+   (s/optional-key :port) any-port
+   (s/optional-key :host) s/Str
+   (s/optional-key :join?) s/Bool
+   (s/optional-key :daemon?) s/Bool
+   (s/optional-key :ssl?) s/Bool
+   (s/optional-key :ssl-port) any-port
+   (s/optional-key :keystore) s/Str
+   (s/optional-key :key-password) s/Str
+   (s/optional-key :truststore) s/Str
+   (s/optional-key :trust-password) s/Str
+   (s/optional-key :max-threads) pos-int 
+   (s/optional-key :min-threads) pos-int
+   (s/optional-key :max-idle-time) pos-int
+   (s/optional-key :client-auth) s/Any
+   (s/optional-key :send-date-header?) s/Bool
+   (s/optional-key :output-buffer-size) pos-int
+   (s/optional-key :request-header-size) pos-int
+   (s/optional-key :response-header-size) pos-int})
 
 (defn new-web-server
   ([port]
@@ -41,9 +44,8 @@
   ([port handler]
    (new-web-server port handler {}))
   ([port handler options]
-   (util/assert-options! "jetty" options allowed-opts)
-   (map->WebServer {:options (merge {:port port :join? false}
-                                    options)
+   (map->WebServer {:options (s/validate Options (merge {:port port :join? false}
+                                                        options))
                     :handler handler})))
 
 

--- a/test/system/components/jetty_test.clj
+++ b/test/system/components/jetty_test.clj
@@ -17,4 +17,31 @@
   (alter-var-root #'http-server component/stop)
   (is (.isStopped (:server http-server)) "HTTP server stops"))
 
+(deftest http-server-valid-options-does-not-throw
+  (is (new-web-server 8081 handler {:host "example.com"
+                                    :configurator {}
+                                    :join? false
+                                    :daemon? true
+                                    :ssl-port 8443
+                                    :keystore "/tmp/keystore"
+                                    :key-password "keeping"
+                                    :truststore "/tmp/truststore"
+                                    :trust-password "secrets"
+                                    :max-threads 16
+                                    :min-threads 2
+                                    :max-idle-time 12345
+                                    :client-auth {}
+                                    :send-date-header? true
+                                    :output-buffer-size 12345
+                                    :request-header-size 12345
+                                    :response-header-size 12345})))
 
+
+(deftest http-server-port-too-low-throws
+  (is (thrown? RuntimeException (new-web-server -1 handler))))
+
+(deftest http-server-port-too-high-throws
+  (is (thrown? RuntimeException (new-web-server 65536 handler))))
+
+(deftest http-server-max-threads-too-low-throws
+  (is (thrown? RuntimeException (new-web-server 8080 handler {:max-threads 0}))))


### PR DESCRIPTION
Minimal replace of existing assertions.

Could open new issues for:
 - add validation to rest of components
 - add more sophisticated validation eg. types of Jetty configurator or ':truststore only valid when :ssl-port set'
 - refactor out reusable validations like port, hostname, ip-address out and test them independently (couldn't find a lib that already has these - maybe a new little project for networky schemas?)
