### PR TITLE
update http-kit, immutant-web and jetty components to define constrai…

### DIFF
--- a/src/system/components/http_kit.clj
+++ b/src/system/components/http_kit.clj
@@ -24,13 +24,15 @@
    (s/optional-key :max-body) sc/PosInt
    (s/optional-key :max-line) sc/PosInt})
 
-(defn new-web-server
-  ([port]
+(s/defn ^:always-validate new-web-server :- WebServer
+  ([port :- sc/Port]
    (new-web-server port nil {}))
-  ([port handler]
+  ([port :- sc/Port
+    handler]
    (new-web-server port handler {}))
-  ([port handler options]
-   (map->WebServer {:options (s/validate Options 
-                                         (merge {:port port}
-                                                options))
+  ([port :- sc/Port
+    handler
+    options :- Options]
+   (map->WebServer {:options (merge {:port port}
+                                    options)
                     :handler handler})))

--- a/src/system/components/immutant_web.clj
+++ b/src/system/components/immutant_web.clj
@@ -23,12 +23,15 @@
    (s/optional-key :dispatch?) s/Bool
    (s/optional-key :servlet-name) s/Str})
 
-(defn new-web-server
-  ([port]
+(s/defn ^:always-validate new-web-server :- WebServer
+  ([port :- sc/Port]
    (new-web-server port nil {}))
-  ([port handler]
+  ([port :- sc/Port
+    handler]
    (new-web-server port handler {}))
-  ([port handler options]
-   (map->WebServer {:options (s/validate Options (merge {:host "0.0.0.0" :port port}
-                                               options))
+  ([port :- sc/Port
+    handler
+    options :- Options]
+   (map->WebServer {:options (merge {:host "0.0.0.0" :port port}
+                                    options)
                     :handler handler})))

--- a/src/system/components/jetty.clj
+++ b/src/system/components/jetty.clj
@@ -36,14 +36,17 @@
    (s/optional-key :request-header-size) sc/PosInt
    (s/optional-key :response-header-size) sc/PosInt})
 
-(defn new-web-server
-  ([port]
+(s/defn ^:always-validate new-web-server :- WebServer
+  ([port :- sc/Port]
    (new-web-server port nil {}))
-  ([port handler]
+  ([port :- sc/Port
+    handler]
    (new-web-server port handler {}))
-  ([port handler options]
-   (map->WebServer {:options (s/validate Options (merge {:port port :join? false}
-                                                        options))
+  ([port :- sc/Port
+    handler
+    options :- Options]
+   (map->WebServer {:options (merge {:port port :join? false}
+                                    options)
                     :handler handler})))
 
 


### PR DESCRIPTION
…nts as type hints and use always-validate metadata to expose better documentation under s/explain and cover more of the API with validation

eg. (s/explain (s/fn-schema new-web-server)) in http-kit namespace says that function returns a WebServer and has three arities with constraints for each.