### PR TITLE
NPE fix in stop fn

### DIFF
--- a/src/system/components/sente.clj
+++ b/src/system/components/sente.clj
@@ -23,7 +23,7 @@
                                                           (event-msg-handler component)
                                                           event-msg-handler))))))
   (stop [component]
-    (if-let [stop-f @router]
+    (if-let [stop-f (and router @router)]
       (assoc component :router (stop-f))
       component)))
 


### PR DESCRIPTION
In case of compilation errors (when the system fails to start at the beginning) it was not possible to recover using (reloaded.repl/reset) due to deref NPE when stopping this component.