### PR TITLE
Create WIP on monitoring API

### DIFF
--- a/README.org
+++ b/README.org
@@ -256,6 +256,12 @@ dependencies. Tests that do require external services being installed
 on your system (such as Mongo, Postgres or Elasticsearch) can be run
 with ~lein test :dependency~. Use ~lein test :all~ to run the full
 test suite.
+
+*** Implementing the monitoring API
+ Implement the ~system.monitoring.monitoring/Monitoring~ protocol if
+ you want your component report back its status.
+
+
 ** Credits
 I wish to thank [[https://github.com/stuartsierra][Stuart Sierra]] for the pioneering and guidance. Special thanks to [[https://github.com/weavejester][James Reeves]] for the [[https://github.com/weavejester/reloaded.repl][reloaded.rep]]l library and general inspiration. Thanks to [[https://github.com/ptaoussanis][Peter Taoussanis]], the friendly OSS contributor, who helped to ‘componentize’ [[https://github.com/ptaoussanis/sente][sente]], an amazing library on its own right.
 ** License

--- a/src/system/components/aleph.clj
+++ b/src/system/components/aleph.clj
@@ -11,7 +11,7 @@
   (stop [component]
     (when server
       (.close server)
-      component)))
+      (assoc component :server nil))))
 
 (defn new-web-server
   ([port]

--- a/src/system/components/cider_repl_server.clj
+++ b/src/system/components/cider_repl_server.clj
@@ -10,7 +10,7 @@
   (stop [component]
     (when server
       (stop-server server)
-      component)))
+      (assoc component :server nil))))
 
 (defn new-cider-repl-server [port]
   (map->CiderReplServer {:port port}))

--- a/src/system/components/http_kit.clj
+++ b/src/system/components/http_kit.clj
@@ -13,7 +13,7 @@
   (stop [component]
     (when server
       (server)
-      component)))
+      (assoc component :server nil))))
 
 (def Options
   {(s/optional-key :ip) sc/IpAddress
@@ -30,7 +30,7 @@
   ([port handler]
    (new-web-server port handler {}))
   ([port handler options]
-   (map->WebServer {:options (s/validate Options 
+   (map->WebServer {:options (s/validate Options
                                          (merge {:port port}
                                                 options))
                     :handler handler})))

--- a/src/system/components/immutant_web.clj
+++ b/src/system/components/immutant_web.clj
@@ -13,7 +13,7 @@
   (stop [component]
     (when server
       (stop server)
-      component)))
+      (assoc component :server nil))))
 
 (def Options
   {(s/optional-key :host) sc/Hostname

--- a/src/system/components/jetty.clj
+++ b/src/system/components/jetty.clj
@@ -27,7 +27,7 @@
    (s/optional-key :key-password) s/Str
    (s/optional-key :truststore) s/Str
    (s/optional-key :trust-password) s/Str
-   (s/optional-key :max-threads) sc/PosInt 
+   (s/optional-key :max-threads) sc/PosInt
    (s/optional-key :min-threads) sc/PosInt
    (s/optional-key :max-idle-time) sc/PosInt
    (s/optional-key :client-auth) s/Any
@@ -45,5 +45,3 @@
    (map->WebServer {:options (s/validate Options (merge {:port port :join? false}
                                                         options))
                     :handler handler})))
-
-

--- a/src/system/components/quartzite.clj
+++ b/src/system/components/quartzite.clj
@@ -11,7 +11,7 @@
   (stop [component]
     (qs/shutdown scheduler)
     component))
-  
+
 (defn new-scheduler
   []
   (map->Scheduler {}))

--- a/src/system/components/repl_server.clj
+++ b/src/system/components/repl_server.clj
@@ -9,8 +9,7 @@
   (stop [component]
     (when server
       (stop-server server)
-      component)))
+      (assoc component :server nil))))
 
 (defn new-repl-server [port]
   (map->ReplServer {:port port}))
-

--- a/src/system/core.clj
+++ b/src/system/core.clj
@@ -1,5 +1,5 @@
 (ns system.core
-  (:require 
+  (:require
    [com.stuartsierra.component :as component]))
 
 (defmacro defsystem

--- a/src/system/monitoring/adi.clj
+++ b/src/system/monitoring/adi.clj
@@ -1,0 +1,9 @@
+(ns system.monitoring.adi
+  (:require [system.monitoring.monitoring :as m]
+            [adi.core :as adi]
+            [adi.core.types :refer [map->Adi]]))
+
+(extend-type adi.core.types.Adi
+  m/Monitoring
+  (status [component]
+    (if (:connection component) :running :down)))

--- a/src/system/monitoring/aleph.clj
+++ b/src/system/monitoring/aleph.clj
@@ -1,0 +1,9 @@
+(ns system.monitoring.aleph
+  (:require system.components.aleph
+            [system.monitoring.monitoring :as m])
+  (:import [system.components.aleph WebServer]))
+
+(extend-type WebServer
+  m/Monitoring
+  (status [component]
+    (if (:server component) :running :down)))

--- a/src/system/monitoring/cider_repl_server.clj
+++ b/src/system/monitoring/cider_repl_server.clj
@@ -1,0 +1,9 @@
+(ns system.monitoring.cider-repl-server
+  (:require system.components.cider-repl-server
+            [system.monitoring.monitoring :as m])
+  (:import [system.components.cider_repl_server CiderReplServer]))
+
+(extend-type CiderReplServer
+  m/Monitoring
+  (status [component]
+    (if (:server component) :running :down)))

--- a/src/system/monitoring/datomic.clj
+++ b/src/system/monitoring/datomic.clj
@@ -1,0 +1,9 @@
+(ns system.monitoring.datomic
+  (:require system.components.datomic
+            [system.monitoring.monitoring :as m])
+  (:import [system.components.datomic Datomic]))
+
+(extend-type Datomic
+  m/Monitoring
+  (status [component]
+    (if (:conn component) :running :down)))

--- a/src/system/monitoring/elasticsearch.clj
+++ b/src/system/monitoring/elasticsearch.clj
@@ -1,0 +1,9 @@
+(ns system.monitoring.elasticsearch
+  (:require system.components.elasticsearch
+            [system.monitoring.monitoring :as m])
+  (:import [system.components.elasticsearch Elasticsearch]))
+
+(extend-type Elasticsearch
+  m/Monitoring
+  (status [component]
+    (if (:client component) :running :down)))

--- a/src/system/monitoring/etsy.clj
+++ b/src/system/monitoring/etsy.clj
@@ -1,0 +1,9 @@
+(ns system.monitoring.etsy
+  (:require system.components.etsy
+            [system.monitoring.monitoring :as m])
+  (:import [system.components.etsy Etsy]))
+
+(extend-type Etsy
+  m/Monitoring
+  (status [component]
+    (if (:client component) :running :down)))

--- a/src/system/monitoring/http_kit.clj
+++ b/src/system/monitoring/http_kit.clj
@@ -1,0 +1,9 @@
+(ns system.monitoring.http-kit
+  (:require system.components.http-kit
+            [system.monitoring.monitoring :as m])
+  (:import [system.components.http_kit WebServer]))
+
+(extend-type WebServer
+  m/Monitoring
+  (status [component]
+    (if (:server component) :running :down)))

--- a/src/system/monitoring/immutant_web.clj
+++ b/src/system/monitoring/immutant_web.clj
@@ -1,0 +1,9 @@
+(ns system.monitoring.immutant-web
+  (:require system.components.aleph
+            [system.monitoring.monitoring :as m])
+  (:import [system.components.immutant_web WebServer]))
+
+(extend-type WebServer
+  m/Monitoring
+  (status [component]
+    (if (:server component) :running :down)))

--- a/src/system/monitoring/jdbc.clj
+++ b/src/system/monitoring/jdbc.clj
@@ -1,0 +1,12 @@
+(ns system.monitoring.jdbc
+  (:require system.components.jdbc
+            [system.monitoring.monitoring :as m])
+  (:import [system.components.jdbc JDBCDatabase]))
+
+(extend-protocol m/Monitoring
+  JDBCDatabase
+  (status [component]
+    (if (:connection component) :running :down))
+  clojure.lang.PersistentArrayMap
+  (status [component]
+    (if (:connection component) :running :down)))

--- a/src/system/monitoring/jetty.clj
+++ b/src/system/monitoring/jetty.clj
@@ -1,0 +1,9 @@
+(ns system.monitoring.jetty
+  (:require system.components.jetty
+            [system.monitoring.monitoring :as m])
+  (:import [system.components.jetty WebServer]))
+
+(extend-type WebServer
+  m/Monitoring
+  (status [component]
+    (if (.isStopped (:server component)) :down :running)))

--- a/src/system/monitoring/mongo.clj
+++ b/src/system/monitoring/mongo.clj
@@ -1,0 +1,9 @@
+(ns system.monitoring.mongo
+  (:require system.components.mongo
+            [system.monitoring.monitoring :as m])
+  (:import [system.components.mongo Mongo]))
+
+(extend-type Mongo
+  m/Monitoring
+  (status [component]
+    (if (and (:db component) (:conn component)) :running :down)))

--- a/src/system/monitoring/monitoring.clj
+++ b/src/system/monitoring/monitoring.clj
@@ -1,0 +1,11 @@
+(ns system.monitoring.monitoring
+  "Monitoring API. This namespace defines the `Monitoring' protocol,
+  alongside a default implementation that can be used to query the
+  systems about their status.
+
+  The default implementation returns `:unknown'.")
+
+(defprotocol Monitoring
+  "Protocol defining a single function, `status', that different
+  components can use to expose the current status."
+  (status [c]))

--- a/src/system/monitoring/neo4j.clj
+++ b/src/system/monitoring/neo4j.clj
@@ -1,0 +1,9 @@
+(ns system.monitoring.neo4j
+  (:require system.components.neo4j
+            [system.monitoring.monitoring :as m])
+  (:import [system.components.neo4j Neo4j]))
+
+(extend-type Neo4j
+  m/Monitoring
+  (status [component]
+    (if (:conn component) :running :down)))

--- a/src/system/monitoring/quartzite.clj
+++ b/src/system/monitoring/quartzite.clj
@@ -1,0 +1,12 @@
+(ns system.monitoring.quartzite
+  (:require system.components.quartzite
+            [system.monitoring.monitoring :as m]
+            clojurewerkz.quartzite.scheduler)
+  (:import [system.components.quartzite Scheduler]))
+
+(extend-type Scheduler
+  m/Monitoring
+  (status [component]
+    (if (clojurewerkz.quartzite.scheduler/shutdown? (:scheduler component))
+      :down
+      :running)))

--- a/src/system/monitoring/repl_server.clj
+++ b/src/system/monitoring/repl_server.clj
@@ -1,0 +1,9 @@
+(ns system.monitoring.repl-server
+  (:require system.components.repl-server
+            [system.monitoring.monitoring :as m])
+  (:import [system.components.repl_server ReplServer]))
+
+(extend-type ReplServer
+  m/Monitoring
+  (status [component]
+    (if (:server component) :running :down)))

--- a/src/system/monitoring/scheduled_executor_service.clj
+++ b/src/system/monitoring/scheduled_executor_service.clj
@@ -1,0 +1,9 @@
+(ns system.monitoring.scheduled-executor-service
+  (:require system.components.scheduled-executor-service
+            [system.monitoring.monitoring :as m])
+  (:import [system.components.scheduled_executor_service Scheduler]))
+
+(extend-type Scheduler
+  m/Monitoring
+  (status [component]
+    (if (.isShutdown (:scheduler component)) :down :running)))

--- a/src/system/monitoring/sente.clj
+++ b/src/system/monitoring/sente.clj
@@ -1,0 +1,9 @@
+(ns system.monitoring.sente
+  (:require system.components.sente
+            [system.monitoring.monitoring :as m])
+  (:import [system.components.sente ChannelSocketServer]))
+
+(extend-type ChannelSocketServer
+  m/Monitoring
+  (status [component]
+    (if (:router component) :running :down)))

--- a/test/system/components/adi_test.clj
+++ b/test/system/components/adi_test.clj
@@ -1,7 +1,9 @@
 (ns system.components.adi-test
   (:require [adi.core :as adi]
             [system.components.adi :refer [new-adi-db]]
+            system.monitoring.adi
             [com.stuartsierra.component :as component]
+            [system.monitoring.monitoring :as monitoring]
             [clojure.test :refer [deftest is]]))
 
 (def db-schema {:person/name [{:type :string}]})
@@ -23,3 +25,9 @@
   (alter-var-root #'adi-db component/start)
   (alter-var-root #'adi-db component/stop)
   (is (nil? (:connection adi-db))))
+
+(deftest adi-monitoring-status
+  (alter-var-root #'adi-db component/start)
+  (is (= (monitoring/status adi-db) :running))
+  (alter-var-root #'adi-db component/stop)
+  (is (= (monitoring/status adi-db) :down)))

--- a/test/system/components/aleph_test.clj
+++ b/test/system/components/aleph_test.clj
@@ -1,7 +1,9 @@
 (ns system.components.aleph-test
   (:require [system.components.aleph :refer [new-web-server]]
-   [com.stuartsierra.component :as component]
-   [clojure.test :refer [testing deftest is]]))
+            system.monitoring.aleph
+            [com.stuartsierra.component :as component]
+            [system.monitoring.monitoring :as monitoring]
+            [clojure.test :refer [testing deftest is]]))
 
 (defn handler [request]
   {:status 200
@@ -14,3 +16,9 @@
   (alter-var-root #'http-server component/start)
   (is (:server http-server) "HTTP server has been added to component")
   (alter-var-root #'http-server component/stop))
+
+(deftest http-server-monitoring-status
+  (alter-var-root #'http-server component/start)
+  (is (= (monitoring/status http-server) :running))
+  (alter-var-root #'http-server component/stop)
+  (is (= (monitoring/status http-server) :down)))

--- a/test/system/components/cider_repl_server_test.clj
+++ b/test/system/components/cider_repl_server_test.clj
@@ -1,19 +1,26 @@
 (ns system.components.cider-repl-server-test
   (:require
    [system.components.cider-repl-server :refer [new-cider-repl-server]]
+   system.monitoring.cider-repl-server
    [com.stuartsierra.component :as component]
+   [system.monitoring.monitoring :as monitoring]
    [clojure.test :refer [deftest is run-tests]]
    [clojure.tools.nrepl :as repl]))
 
 (def repl-server (new-cider-repl-server 8082))
- 
+
 (deftest repl-server-availability
   (alter-var-root #'repl-server component/start)
   (is (:server repl-server) "REPL server has been added to component")
   (is (= [2] (with-open [conn (repl/connect :port 8082)]
                (-> (repl/client conn 1000)
                    (repl/message {:op :eval :code "(+ 1 1)"})
-                   repl/response-values))) 
+                   repl/response-values)))
       "REPL functions normally")
   (alter-var-root #'repl-server component/stop))
 
+(deftest repl-server-monitoring-status
+  (alter-var-root #'repl-server component/start)
+  (is (= (monitoring/status repl-server) :running))
+  (alter-var-root #'repl-server component/stop)
+  (is (= (monitoring/status repl-server) :down)))

--- a/test/system/components/datomic_test.clj
+++ b/test/system/components/datomic_test.clj
@@ -1,6 +1,9 @@
 (ns system.components.datomic-test
-  (:require [system.components.datomic :refer [new-datomic-db]]
+  (:require
+   [system.components.datomic :refer [new-datomic-db]]
+   system.monitoring.datomic
    [com.stuartsierra.component :as component]
+   [system.monitoring.monitoring :as monitoring]
    [datomic.api :as d]
    [clojure.test :refer [deftest testing is]]))
 
@@ -14,3 +17,9 @@
            datomic.peer.LocalConnection))
     (is (d/delete-database uri))
     (alter-var-root #'datomic-db component/stop)))
+
+(deftest datomic-monitoring-status
+  (alter-var-root #'datomic-db component/start)
+  (is (= (monitoring/status datomic-db) :running))
+  (alter-var-root #'datomic-db component/stop)
+  (is (= (monitoring/status datomic-db) :down)))

--- a/test/system/components/etsy_test.clj
+++ b/test/system/components/etsy_test.clj
@@ -1,7 +1,10 @@
 (ns system.components.etsy-test
-  (:require [system.components.etsy :refer [new-etsy-client]]
-            [com.stuartsierra.component :as component]
-            [clojure.test :refer [deftest is]]))
+  (:require
+   [system.components.etsy :refer [new-etsy-client]]
+   system.monitoring.etsy
+   [com.stuartsierra.component :as component]
+   [system.monitoring.monitoring :as monitoring]
+   [clojure.test :refer [deftest is]]))
 
 (def etsy-client (new-etsy-client "123" "1234"))
 
@@ -10,3 +13,8 @@
   (is (:client etsy-client) "a client is present")
   (alter-var-root #'etsy-client component/stop))
 
+(deftest etsy-client-monitoring-status
+  (alter-var-root #'etsy-client component/start)
+  (is (= (monitoring/status etsy-client) :running))
+  (alter-var-root #'etsy-client component/stop)
+  (is (= (monitoring/status etsy-client) :down)))

--- a/test/system/components/h2_test.clj
+++ b/test/system/components/h2_test.clj
@@ -1,8 +1,11 @@
 (ns system.components.h2-test
   (:use clojure.test)
-  (:require [system.components.h2 :as h2]
-            [clojure.java.jdbc :as jdbc]
-            [com.stuartsierra.component :as component]))
+  (:require
+   [system.components.h2 :as h2]
+   system.monitoring.jdbc
+   [clojure.java.jdbc :as jdbc]
+   [com.stuartsierra.component :as component]
+   [system.monitoring.monitoring :as monitoring]))
 
 (deftest test-mem-h2
   (let [db (h2/new-h2-database h2/DEFAULT-MEM-SPEC)
@@ -11,3 +14,14 @@
     (jdbc/insert! db "Temp" {:id 1 :name "Bob"})
     (is (= "Bob" (:name (first (jdbc/query db ["SELECT * FROM Temp;"])))))
     (component/stop db)))
+
+(deftest mem-h2-monitoring-status
+  (is (= (-> (h2/new-h2-database h2/DEFAULT-MEM-SPEC)
+             component/start
+             monitoring/status)
+         :running))
+  (is (= (-> (h2/new-h2-database h2/DEFAULT-MEM-SPEC)
+             component/start
+             component/stop
+             monitoring/status)
+         :down)))

--- a/test/system/components/http_kit_test.clj
+++ b/test/system/components/http_kit_test.clj
@@ -1,7 +1,9 @@
 (ns system.components.http-kit-test
   (:require [system.components.http-kit :refer [new-web-server]]
-   [com.stuartsierra.component :as component]
-   [clojure.test :refer [testing deftest is]]))
+            system.monitoring.http-kit
+            [com.stuartsierra.component :as component]
+            [system.monitoring.monitoring :as monitoring]
+            [clojure.test :refer [testing deftest is]]))
 
 (defn handler [request]
   {:status 200
@@ -9,7 +11,7 @@
    :body "Hello World"})
 
 (def http-server (new-web-server 8081 handler))
- 
+
 (deftest http-server-lifecycle
   (alter-var-root #'http-server component/start)
   (is (:server http-server) "HTTP server has been added to component")
@@ -24,5 +26,8 @@
 (deftest http-server-options-invalid-port-throws
   (is (thrown? RuntimeException (new-web-server -1 handler {:thread 7}))))
 
-
-
+(deftest http-server-monitoring-status
+  (alter-var-root #'http-server component/start)
+  (is (= (monitoring/status http-server) :running))
+  (alter-var-root #'http-server component/stop)
+  (is (= (monitoring/status http-server) :down)))

--- a/test/system/components/immutant_web_test.clj
+++ b/test/system/components/immutant_web_test.clj
@@ -1,6 +1,9 @@
 (ns system.components.immutant-web-test
-  (:require [system.components.immutant-web :refer [new-web-server]]
+  (:require
+   [system.components.immutant-web :refer [new-web-server]]
+   system.monitoring.immutant-web
    [com.stuartsierra.component :as component]
+   [system.monitoring.monitoring :as monitoring]
    [clojure.test :refer [testing deftest is]]))
 
 (defn handler [request]
@@ -20,3 +23,9 @@
 
 (deftest http-server-illegal-dispatch-option-throws
   (is (thrown? RuntimeException (new-web-server 8080 handler {:dispatch? "bob"}))))
+
+(deftest http-server-monitoring-status
+  (alter-var-root #'http-server component/start)
+  (is (= (monitoring/status http-server) :running))
+  (alter-var-root #'http-server component/stop)
+  (is (= (monitoring/status http-server) :down)))

--- a/test/system/components/jetty_test.clj
+++ b/test/system/components/jetty_test.clj
@@ -1,6 +1,9 @@
 (ns system.components.jetty-test
-  (:require [system.components.jetty :refer [new-web-server]]
+  (:require
+   [system.components.jetty :refer [new-web-server]]
+   system.monitoring.jetty
    [com.stuartsierra.component :as component]
+   [system.monitoring.monitoring :as monitoring]
    [clojure.test :refer [testing deftest is]]))
 
 (defn handler [request]
@@ -9,7 +12,7 @@
    :body "Hello World"})
 
 (def http-server (new-web-server 8081 handler))
- 
+
 (deftest http-server-lifecycle
   (alter-var-root #'http-server component/start)
   (is (:server http-server) "HTTP server has been added to component")
@@ -45,3 +48,9 @@
 
 (deftest http-server-max-threads-too-low-throws
   (is (thrown? RuntimeException (new-web-server 8080 handler {:max-threads 0}))))
+
+(deftest http-server-monitoring-status
+  (alter-var-root #'http-server component/start)
+  (is (= (monitoring/status http-server) :running))
+  (alter-var-root #'http-server component/stop)
+  (is (= (monitoring/status http-server) :down)))

--- a/test/system/components/quartzite_test.clj
+++ b/test/system/components/quartzite_test.clj
@@ -1,8 +1,11 @@
 (ns system.components.quartzite-test
-  (:require [clojure.test :refer [deftest is]]
-            [clojurewerkz.quartzite.scheduler :as qs]
-            [com.stuartsierra.component :as component]
-            [system.components.quartzite :as quartz]))
+  (:require
+   [system.components.quartzite :as quartz]
+   system.monitoring.quartzite
+   [com.stuartsierra.component :as component]
+   [system.monitoring.monitoring :as monitoring]
+   [clojurewerkz.quartzite.scheduler :as qs]
+   [clojure.test :refer [deftest is]]))
 
 (def scheduler (quartz/new-scheduler))
 
@@ -11,3 +14,10 @@
   (is (qs/started? (:scheduler scheduler)) "the scheduler is running")
   (alter-var-root #'scheduler component/stop)
   (is (qs/shutdown? (:scheduler scheduler)) "the scheduler is stopped"))
+
+
+(deftest quartzite-monitoring-status
+  (alter-var-root #'scheduler component/start)
+  (is (= (monitoring/status scheduler) :running))
+  (alter-var-root #'scheduler component/stop)
+  (is (= (monitoring/status scheduler) :down)))

--- a/test/system/components/repl_server_test.clj
+++ b/test/system/components/repl_server_test.clj
@@ -1,19 +1,26 @@
 (ns system.components.repl-server-test
   (:require
    [system.components.repl-server :refer [new-repl-server]]
+   system.monitoring.repl-server
    [com.stuartsierra.component :as component]
+   [system.monitoring.monitoring :as monitoring]
    [clojure.test :refer [deftest is run-tests]]
    [clojure.tools.nrepl :as repl]))
 
-
 (def repl-server (new-repl-server 8082))
- 
+
 (deftest repl-server-availability
   (alter-var-root #'repl-server component/start)
   (is (:server repl-server) "REPL server has been added to component")
   (is (= [2] (with-open [conn (repl/connect :port 8082)]
                (-> (repl/client conn 1000)
                    (repl/message {:op :eval :code "(+ 1 1)"})
-                   repl/response-values))) 
+                   repl/response-values)))
       "REPL functions normally")
   (alter-var-root #'repl-server component/stop))
+
+(deftest repl-server-monitoring-status
+  (alter-var-root #'repl-server component/start)
+  (is (= (monitoring/status repl-server) :running))
+  (alter-var-root #'repl-server component/stop)
+  (is (= (monitoring/status repl-server) :down)))

--- a/test/system/components/scheduled_executor_service_test.clj
+++ b/test/system/components/scheduled_executor_service_test.clj
@@ -1,7 +1,10 @@
 (ns system.components.scheduled-executor-service-test
-  (:require [clojure.test :refer [deftest is]]
-            [com.stuartsierra.component :as component]
-            [system.components.scheduled-executor-service :refer [new-scheduler]]))
+  (:require
+   [system.components.scheduled-executor-service :refer [new-scheduler]]
+   system.monitoring.scheduled-executor-service
+   [com.stuartsierra.component :as component]
+   [system.monitoring.monitoring :as monitoring]
+   [clojure.test :refer [deftest is]]))
 
 (def scheduler (new-scheduler (+ 2 (.availableProcessors (Runtime/getRuntime)))))
 
@@ -10,3 +13,9 @@
   (is (= java.util.concurrent.ScheduledThreadPoolExecutor (type (:scheduler scheduler))) "the scheduler is running")
   (alter-var-root #'scheduler component/stop)
   (is (.isShutdown (:scheduler scheduler)) "the scheduler is stopped"))
+
+(deftest scheduler-monitoring-status
+  (alter-var-root #'scheduler component/start)
+  (is (= (monitoring/status scheduler) :running))
+  (alter-var-root #'scheduler component/stop)
+  (is (= (monitoring/status scheduler) :down)))

--- a/test/system/components/sente_test.clj
+++ b/test/system/components/sente_test.clj
@@ -1,9 +1,12 @@
 (ns system.components.sente-test
-  (:require [system.components.sente :refer [new-channel-socket-server]]
-            [com.stuartsierra.component :as component]
-            [taoensso.sente :as sente]
-            [taoensso.sente.server-adapters.http-kit :refer [http-kit-adapter]]
-            [clojure.test :refer [deftest testing is]]))
+  (:require
+   [system.components.sente :refer [new-channel-socket-server]]
+   system.monitoring.sente
+   [com.stuartsierra.component :as component]
+   [system.monitoring.monitoring :as monitoring]
+   [taoensso.sente :as sente]
+   [taoensso.sente.server-adapters.http-kit :refer [http-kit-adapter]]
+   [clojure.test :refer [deftest testing is]]))
 
 (def channel-sockets (new-channel-socket-server (fn []) http-kit-adapter))
 
@@ -12,3 +15,9 @@
   (is (ifn? (:chsk-send! channel-sockets)))
   (is (map? @(:connected-uids channel-sockets)))
   (alter-var-root #'channel-sockets component/stop))
+
+(deftest channel-sockets-monitoring-status
+  (alter-var-root #'channel-sockets component/start)
+  (is (= (monitoring/status channel-sockets) :running))
+  (alter-var-root #'channel-sockets component/stop)
+  (is (= (monitoring/status channel-sockets) :down)))


### PR DESCRIPTION
Here’s a first take on #64 

#### Recap
- Create protocol `system.components.monitoring/Monitoring` with a single function, `-status` and a default implementation on `Object`.
- Modify `system.components.http-kit` to implement the protocol
- Expose `-status` via `system.core/status`

#### Questions to ponder
- Is `system.components` the correct namespace? Maybe not, maybe should be something like `system.monitoring`?
- Is the exposure in `system.core` desirable? Especially if we move the protocol.

#### Open items
These are things to be done if and when we agree on the overall proposal
- Tests
- Docstrings
- Function returning the overall status of a system
- Extending the implementation to the other components