### PR TITLE
make jdbc component stop function idempotent

### DIFF
--- a/src/system/components/jdbc.clj
+++ b/src/system/components/jdbc.clj
@@ -7,12 +7,13 @@
 (defrecord JDBCDatabase [db-spec connection init-fn]
   component/Lifecycle
   (start [component]
-    (let [conn (jdbc/get-connection (:db-spec component))
+    (let [conn (or connection (jdbc/get-connection (:db-spec component)))
           _ (when init-fn (init-fn db-spec))]
       (assoc component :connection conn)))
   (stop [component]
-    (.close connection)
-    (assoc component :connection nil)))
+    (when-let [conn (:connection component)]
+      (.close conn))
+    (dissoc component :connection)))
 
 (defn new-database 
   ([db-spec]


### PR DESCRIPTION
Thanks so much for this library, I'm loving it!

This is just a small change that ensures the stop method will close the connection created by the component (instead of the connection passed to the constructor). It also makes the stop function  idempotent.

Also, on the off chance someone instantiates a JDBCDatabase Record directly with an existing connection, this change will ensure that the component will use that connection rather than creating a new one. 

Hope this is useful. If not feel free to delete!