### PR TITLE
add leinigen test selectors

### DIFF
--- a/README.org
+++ b/README.org
@@ -247,7 +247,14 @@ To help choose if ~system~ is right for you, here are a couple of tips. Take a c
 
 
 ** Contributing
-Please fork and issue a pull request to add more components. Please don't forget to include tests. You can refer to the existing ones to get started.
+Please fork and issue a pull request to add more components. Please
+don't forget to include tests. You can refer to the existing ones to
+get started.
+
+Calling ~lein test~ will run most of the tests. Since some of the unit
+tests are dependent upon external services being started (such as
+mongo, postgres, and elasticsearch), use ~lein test :dependency~ to
+run the full test suite.
 ** Credits
 I wish to thank [[https://github.com/stuartsierra][Stuart Sierra]] for the pioneering and guidance. Special thanks to [[https://github.com/weavejester][James Reeves]] for the [[https://github.com/weavejester/reloaded.repl][reloaded.rep]]l library and general inspiration. Thanks to [[https://github.com/ptaoussanis][Peter Taoussanis]], the friendly OSS contributor, who helped to ‘componentize’ [[https://github.com/ptaoussanis/sente][sente]], an amazing library on its own right.
 ** License

--- a/project.clj
+++ b/project.clj
@@ -43,4 +43,7 @@
                                                 org.ow2.asm/asm-commons]]
                                   [aleph "0.4.0-alpha9"]]}}
   :scm {:name "git"
-        :url "https://github.com/danielsz/system"})
+        :url "https://github.com/danielsz/system"}
+  :test-selectors {:default (complement :dependency)
+                   :dependency :dependency}
+)

--- a/test/system/components/elasticsearch_test.clj
+++ b/test/system/components/elasticsearch_test.clj
@@ -4,7 +4,7 @@
             [clojure.test :refer [deftest is]])
   (:import [org.elasticsearch.action.search SearchRequest]))
 
-(deftest test-elasticsearch
+(deftest ^:dependency test-elasticsearch
   (let [cluster-name (str "elasticsearch_" (System/getProperty "user.name"))
         elasticsearch-db (component/start
                            (new-elasticsearch-db

--- a/test/system/components/mongo_test.clj
+++ b/test/system/components/mongo_test.clj
@@ -35,7 +35,7 @@
     (is (= initial-cc (current-connections db)))
     (mg/disconnect conn)))
 
-(deftest mongo-production
+(deftest ^:dependency mongo-production
   (alter-var-root #'mongo-db-prod component/start)
   (is (:db mongo-db-prod) "DB has been added to component")
   (is (= clojure.lang.PersistentHashSet (type (db/get-collection-names (:db mongo-db-prod)))) "Collections on DB is a set")
@@ -44,7 +44,7 @@
   (alter-var-root #'mongo-db-prod component/stop)
   (is (nil? (:db mongo-db-prod)) "DB is stopped"))
 
-(deftest mongo-production-with-options
+(deftest ^:dependency mongo-production-with-options
   (alter-var-root #'mongo-db-with-options component/start)
   (is (:db mongo-db-with-options) "DB has been added to component")
   (is (= clojure.lang.PersistentHashSet (type (db/get-collection-names (:db mongo-db-with-options)))) "Collections on DB is a set")
@@ -53,7 +53,7 @@
   (alter-var-root #'mongo-db-with-options component/stop)
   (is (nil? (:db mongo-db-with-options)) "DB is stopped"))
 
-(deftest mongo-production-with-options-and-init
+(deftest ^:dependency mongo-production-with-options-and-init
   (let [db #'mongo-db-with-options-and-init]
     (alter-var-root db component/start)
     (is (:db mongo-db-with-options-and-init) "DB has been added to component")
@@ -67,20 +67,20 @@
     (alter-var-root db component/stop)
     (is (nil? (:db mongo-db-with-options-and-init)) "DB is stopped")))
 
-(deftest mongo-development
+(deftest ^:dependency mongo-development
   (alter-var-root #'mongo-db-dev component/start)
   (is (:db mongo-db-dev) "DB has been added to component")
   (create-and-drop-collection (:db mongo-db-dev))
   (alter-var-root #'mongo-db-dev component/stop)
   (is (nil? (:db mongo-db-dev)) "DB is stopped"))
 
-(deftest mongo-development-idempotence
+(deftest ^:dependency mongo-development-idempotence
   (alter-var-root #'mongo-db-dev component/start)
   (test-open-connections #(alter-var-root #'mongo-db-dev component/start))
   (alter-var-root #'mongo-db-dev component/stop)
   (is (nil? (:db mongo-db-dev)) "DB is stopped"))
 
-(deftest mongo-indices
+(deftest ^:dependency mongo-indices
   (alter-var-root #'mongo-with-indices component/start)
   (is (:db mongo-with-indices) "DB has been added to component")
   (is (= clojure.lang.PersistentHashSet (type (db/get-collection-names (:db mongo-with-indices)))) "Collections on DB is a set")
@@ -91,6 +91,6 @@
   (alter-var-root #'mongo-with-indices component/stop)
   (is (nil? (:db mongo-with-indices)) "DB is stopped"))
 
-(deftest mongo-with-bogus-options
+(deftest ^:dependency mongo-with-bogus-options
   (is (= {:bogus 'disallowed-key} (try (new-mongo-db "127.0.0.1" 27017 "test" {:bogus true})
                                         (catch clojure.lang.ExceptionInfo e (:error (ex-data e)))))))

--- a/test/system/components/neo4j_test.clj
+++ b/test/system/components/neo4j_test.clj
@@ -7,7 +7,7 @@
 (def uri "http://localhost:7474/db/data/")
 (def data {:foo "bar"})
 
-(deftest test-neo4j
+(deftest ^:dependency test-neo4j
   (let [{:keys [conn] :as db} (-> (neo4j/new-neo4j-db uri)
                                   component/start)]
     (is conn "conn has been added to component")

--- a/test/system/components/postgres_test.clj
+++ b/test/system/components/postgres_test.clj
@@ -15,7 +15,7 @@
    :password ""
    :host "127.0.0.1"})
 
-(deftest postgres-test-create-table-and-insert
+(deftest ^:dependency postgres-test-create-table-and-insert
   (let [db (component/start
             (p/new-postgres-database test-db-spec))
         msg "It works!"]


### PR DESCRIPTION
Here's another small update that I found helpful when testing the jdbc changes. This PR makes it so that `lein test` will skip tests that rely on external processes (postgres, mongo, and elasticsearch). 

In order to run the full test suite, use the following command: 

```
lein test :integration
```

