### PR TITLE
Fix bad test namespace

### DIFF
--- a/test/system/schema_test.clj
+++ b/test/system/schema_test.clj
@@ -1,4 +1,4 @@
-(ns system.schema_test
+(ns system.schema-test
   (:require [system.schema :as sc]
             [schema.core :as s]
             [clojure.test :refer [deftest is]]))


### PR DESCRIPTION
Sorry for the original error! Was preventing tools like CIDER from being able to run test.