### PR TITLE
Disconnect Sente from server on client stop

### DIFF
--- a/src/system/components/sente.cljc
+++ b/src/system/components/sente.cljc
@@ -63,9 +63,11 @@
            (assoc component :router (atom (sente/start-chsk-router! ch-recv handler)))
            component)))
      (stop [component]
-       (if-let [stop-f (and router @router)]
-         (assoc component :router (stop-f))
-         component))))
+       (when chsk
+         (sente/chsk-disconnect! chsk))
+       (when-let [stop-f (and router @router)]
+         (stop-f))
+       (dissoc component :router :chsk :ch-recv :chsk-send! :chsk-state))))
 
 #?(:cljs
    (defn new-channel-socket-client


### PR DESCRIPTION
Without this Sente will keep a connection open and pinging the server after stop is called.  As an aside, router does not need to be an atom.