### PR TITLE
don't dissoc components

### DIFF
--- a/src/system/components/hara_io_scheduler.clj
+++ b/src/system/components/hara_io_scheduler.clj
@@ -10,7 +10,7 @@
     (assoc component :scheduler scheduler))
   (stop [component]
     (sch/stop! scheduler)
-    (dissoc component :scheduler)))
+    (assoc component :scheduler nil)))
 
 (defn new-scheduler
   ([]

--- a/src/system/components/jdbc.clj
+++ b/src/system/components/jdbc.clj
@@ -13,7 +13,7 @@
   (stop [component]
     (when-let [conn (:connection component)]
       (.close conn))
-    (dissoc component :connection)))
+    (assoc component :connection nil)))
 
 (defn new-database 
   ([db-spec]

--- a/src/system/components/mongo.clj
+++ b/src/system/components/mongo.clj
@@ -39,7 +39,9 @@
   (stop [component]
     (when conn (try (mg/disconnect conn)
                     (catch Throwable t (println t "Error when stopping Mongo component"))))
-    (dissoc component :db :conn)))
+    (-> component
+        (dissoc :db)
+        (assoc :conn nil))))
 
 (defn new-mongo-db
   ([]

--- a/src/system/components/sente.cljc
+++ b/src/system/components/sente.cljc
@@ -67,7 +67,12 @@
          (sente/chsk-disconnect! chsk))
        (when-let [stop-f router]
          (stop-f))
-       (dissoc component :router :chsk :ch-recv :chsk-send! :chsk-state))))
+       (assoc component
+              :router nil
+              :chsk nil
+              :ch-chsk nil
+              :chsk-send! nil
+              :chsk-state nil))))
 
 #?(:cljs
    (defn new-channel-socket-client

--- a/test/system/components/hara_io_scheduler_test.clj
+++ b/test/system/components/hara_io_scheduler_test.clj
@@ -12,4 +12,4 @@
   (alter-var-root #'scheduler component/start)
   (is (= (clock-started? (get-in scheduler [:scheduler :clock])) true))
   (alter-var-root #'scheduler component/stop)
-  (is (empty? scheduler)))
+  (is (nil? (:scheduler scheduler))))


### PR DESCRIPTION
Following our discussion in danielsz/system#71 I replaced all `(dissoc component :some-key)` calls with `(assoc component :some-key nil)` so stopped components can be started again.