### PR TITLE
sente: Add options to component before wrapping

### DIFF
--- a/src/system/components/sente.cljc
+++ b/src/system/components/sente.cljc
@@ -19,16 +19,18 @@
   (start [component]
     (let [handler (get-in component [:sente-handler :handler] handler)
           {:keys [ch-recv send-fn ajax-post-fn ajax-get-or-ws-handshake-fn connected-uids]}
-          (sente/make-channel-socket-server! web-server-adapter options)]
+          (sente/make-channel-socket-server! web-server-adapter options)
+          component (assoc component
+                           :ring-ajax-post ajax-post-fn
+                           :ring-ajax-get-or-ws-handshake ajax-get-or-ws-handshake-fn
+                           :ch-chsk ch-recv
+                           :chsk-send! send-fn
+                           :connected-uids connected-uids)]
       (assoc component
-        :ring-ajax-post ajax-post-fn
-        :ring-ajax-get-or-ws-handshake ajax-get-or-ws-handshake-fn
-        :ch-chsk ch-recv
-        :chsk-send! send-fn
-        :connected-uids connected-uids
-        :router (sente/start-chsk-router! ch-recv (if (:wrap-component? options)
-                                                    (handler component)
-                                                    handler)))))
+             :router (sente/start-chsk-router!
+                      ch-recv (if (:wrap-component? options)
+                                (handler component)
+                                handler)))))
   (stop [component]
     (if-let [stop-f router]
       (assoc component :router (stop-f))


### PR DESCRIPTION
This allows the wrapper function (in the case the `:wrap-component?`
option is used) access to the websocket channel helper component values
such as `:connected-uids`.