### PR TITLE
Fix bad ns form

### DIFF
--- a/src/system/repl.clj
+++ b/src/system/repl.clj
@@ -1,9 +1,9 @@
 (ns system.repl
-  (require [com.stuartsierra.component :as component]
-           [clojure.tools.namespace.track :as track]
-           [system.reload :as reload]
-           [clojure.stacktrace :as st]
-           [io.aviso.ansi :refer [bold-red bold-yellow]] ))
+  (:require [com.stuartsierra.component :as component]
+            [clojure.tools.namespace.track :as track]
+            [system.reload :as reload]
+            [clojure.stacktrace :as st]
+            [io.aviso.ansi :refer [bold-red bold-yellow]] ))
 
 
 (declare system)


### PR DESCRIPTION
This will fail compilation due to new core specs in Clojure 1.9.0-alpha11.