### PR TITLE
`system.components.watcher` start/stop idempotency

### DIFF
--- a/src/system/components/watcher.clj
+++ b/src/system/components/watcher.clj
@@ -6,10 +6,13 @@
 (extend-protocol component/Lifecycle
   Watcher
   (component/start [watcher]
-    (watch/start-watcher watcher))
-
+    (if-not (:running watcher)
+      (watch/start-watcher watcher)
+      watcher))
   (component/stop [watcher]
-    (watch/stop-watcher watcher)))
+    (if (:running watcher)
+      (watch/stop-watcher watcher)
+      watcher)))
 
 (defn new-watcher [paths callback & [config]]
   (watch/watcher paths callback config))

--- a/test/system/components/watcher_test.clj
+++ b/test/system/components/watcher_test.clj
@@ -19,4 +19,22 @@
         (spit "test.watcher" "Hello")
         @result)))
 
+(deftest start-watcher-idempotent
+  (let [watcher (new-watcher ["."]
+                             (constantly nil)
+                             {})
+        started (component/start watcher)]
+    (is (identical? started (component/start started)))
+    (component/stop watcher)))
+
+(deftest stop-watcher-idempotent
+  (let [watcher (new-watcher ["."]
+                             (constantly nil)
+                             {})
+        started (component/start watcher)
+        stopped (component/stop started)]
+    (is (identical? stopped (component/stop stopped)))))
+
 (watcher-lifecycle)
+(start-watcher-idempotent)
+(stop-watcher-idempotent)


### PR DESCRIPTION
Add a tiny bit of metadata on start/stop of the component in
order to make sure we don't run `stop` on a stopped component (causing
`NullPointerException`s).