### PR TITLE
Add docstrings to system.components.handler

### DIFF
--- a/src/system/components/handler.clj
+++ b/src/system/components/handler.clj
@@ -68,7 +68,7 @@
          :endpoint-b-middleware (new-middleware {:middleware [,,,]})
          :middleware (new-middleware {:middleware [,,,]})
          :handler (-> (new-handler)
-                      (component/using [:endpoint :middleware]))
+                      (component/using [:endpoint-a :endpoint-b :middleware]))
          :jetty (-> (new-web-server port)
                     (component/using [:handler])))"
   ([] (->Handler)))


### PR DESCRIPTION
It took me quite a bit of staring at this code to see what it does exactly, so I figured some docstrings would be nice. 

I hope you're open to this kind of contribution. While I'm a big fan of System, I'm finding a lack of documentation for individual components a real stumbling block.

Thanks!