### PR TITLE
rabbitmq try/catch on close

### DIFF
--- a/src/system/components/rabbitmq.clj
+++ b/src/system/components/rabbitmq.clj
@@ -11,8 +11,10 @@
           ch   (lch/open conn)]
       (assoc component :conn conn :ch ch)))
   (stop [component]
-    (rmq/close ch)
-    (rmq/close conn)
+    (try (rmq/close ch)
+         (catch com.rabbitmq.client.AlreadyClosedException e nil))
+    (try (rmq/close conn)
+         (catch com.rabbitmq.client.AlreadyClosedException e nil))
     component))
 
 (defn new-rabbit-mq [uri]


### PR DESCRIPTION
When I'm reloading a system that had a compiling error, I'm unable to restart the system due to already closed exceptions from rabbitmq. Handling already closed exceptions allows a system to recover more gracefully.