### PR TITLE
Added Bidi for routing 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,6 +13,11 @@
                                    [org.clojure/tools.nrepl "0.2.11"]
                                    [cider/cider-nrepl "0.10.1"]
                                    [ring "1.4.0"]
+
+                                   [ring/ring-defaults "0.3.1"]
+                                   [bk/ring-gzip "0.2.1"]
+                                   [bidi "2.1.2"]
+
                                    [im.chit/hara.io.watch "2.1.7"]
                                    [im.chit/hara.io.scheduler "2.3.6"]
                                    [im.chit/adi "0.3.2"]
@@ -31,7 +36,7 @@
                                    [http-kit "2.1.19"]
                                    [org.immutant/web "2.1.2"]
                                    [hikari-cp "1.6.1"]
-                                   [com.taoensso/encore "2.91.0"] 
+                                   [com.taoensso/encore "2.91.0"]
                                    [com.taoensso/carmine "2.16.0"]
                                    [io.replikativ/konserve-carmine "0.1.1"]
                                    [org.elasticsearch/elasticsearch "1.6.0"

--- a/test/system/components/handler_test.clj
+++ b/test/system/components/handler_test.clj
@@ -21,7 +21,8 @@
             [lang-utils.core :refer [contains+? ∘]]))
 
 
-
+;; =============================================================================
+;; Bidi system set up
 (defn config []
   {:http-port  (Integer. 8081)
    :middleware [[wrap-defaults api-defaults]
@@ -43,7 +44,7 @@
         ["articles/" :id "/article.html"] article-handler}])
 
 
-(defn app-system [config]
+(defn bidi-system [config]
   (component/system-map
     :routes     (new-endpoint home-routes)
     :middleware (new-middleware {:middleware (:middleware config)})
@@ -51,18 +52,24 @@
                     (component/using [:routes :middleware]))
     :http       (-> (new-web-server (:http-port config))
                     (component/using [:handler]))))
+;; =============================================================================
+;; End of bidi system setup
 
+(def bs (bidi-system (config)))
 
-(comment
-  (def c (-> (config)
-             app-system
-             component/start))
+(defn bidi-fixtures [f]
+  (alter-var-root #'bs component/start)
+  (f)
+  (alter-var-root #'bs component/stop))
 
+(use-fixtures :each bidi-fixtures)
 
+(deftest check-instance
+  (is (instance? system.components.endpoint.Endpoint (:routes bs)))
+  (is (instance? system.components.middleware.Middleware (:middleware bs)))
+  (is (instance? system.components.handler.Handler (:handler bs))))
 
-
-
-
-
-
-  )
+(deftest bidi
+  (is (= #'bidi.ring/make-handler (get-in bs [:handler :router])))
+  (is (= (home-routes nil)
+         (get-in bs [:handler :routes :routes]))))

--- a/test/system/components/handler_test.clj
+++ b/test/system/components/handler_test.clj
@@ -1,0 +1,68 @@
+(ns system.components.handler-test
+  (:require [clojure.test :refer :all]
+
+            [com.stuartsierra.component :as component]
+
+            [system.components.endpoint :refer [new-endpoint]]
+            [system.components.middleware :refer [new-middleware]]
+            [system.components.jetty :refer [new-web-server]]
+            [system.components.handler :refer [new-handler]]
+
+            [ring.middleware.defaults :refer [wrap-defaults api-defaults]]
+            [ring.middleware.gzip :refer [wrap-gzip]]
+
+            [compojure.core :as compojure :refer [GET]]
+            [compojure.route :refer [not-found]]
+
+            [bidi.ring :as bidi :refer (make-handler)]
+            [ring.util.response :as res]
+
+            [system.components.handler :as h]
+            [lang-utils.core :refer [contains+? ∘]]))
+
+
+
+(defn config []
+  {:http-port  (Integer. 8081)
+   :middleware [[wrap-defaults api-defaults]
+                wrap-gzip]})
+
+
+(defn index-handler
+  [request]
+  (res/response "Homepage"))
+
+
+(defn article-handler
+  [{:keys [route-params]}]
+  (res/response (str "You are viewing article: " (:id route-params))))
+
+
+(defn home-routes [endpoint]
+  ["/" {"index.html" index-handler
+        ["articles/" :id "/article.html"] article-handler}])
+
+
+(defn app-system [config]
+  (component/system-map
+    :routes     (new-endpoint home-routes)
+    :middleware (new-middleware {:middleware (:middleware config)})
+    :handler    (-> (new-handler :bidi)
+                    (component/using [:routes :middleware]))
+    :http       (-> (new-web-server (:http-port config))
+                    (component/using [:handler]))))
+
+
+(comment
+  (def c (-> (config)
+             app-system
+             component/start))
+
+
+
+
+
+
+
+
+  )


### PR DESCRIPTION
For one of my project I am using `system` and the awesome [bidi](https://github.com/juxt/bidi) for routing.

Today it's impossible to use `bidi` with `system` as `compojure` is the default lib, see this issue #110 

### Done : 
- [X] bidi lib added to handler.clj and working
- [X] started to write the handler_test.clj file

### To do : 
- [ ] review this PR 
- [ ] add tests

Thanks for the help