### PR TITLE
Add lambdacd component to system

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -33,6 +33,7 @@
                                    [org.danielsz/benjamin "0.1.0-SNAPSHOT"]
                                    [compojure "1.4.0"]
                                    [http-kit "2.1.19"]
+                                   [lambdacd "0.13.2"]
                                    [org.immutant/web "2.1.2"]
                                    [hikari-cp "1.6.1"]
                                    [com.taoensso/encore "2.91.0"]

--- a/src/system/components/lambdacd.clj
+++ b/src/system/components/lambdacd.clj
@@ -1,0 +1,36 @@
+(ns system.components.lambdacd
+  (:require [com.stuartsierra.component :as component]
+            [lambdacd.core :as lambdacd]
+            [lambdacd.runners :as runners]))
+
+(defn start-pipelines [pipelines]
+  (doseq [pipeline pipelines]
+    (runners/start-one-run-after-another pipeline)))
+
+(defn stop-pipelines [pipelines]
+  (doseq [pipeline pipelines]
+    (when-let [old-ctx (:context pipeline)]
+      ((get-in old-ctx [:config :shutdown-sequence]) old-ctx))))
+
+(defn assemble-pipelines [pipeline-defs config]
+  (map
+   (fn [[pname pdef]]
+     (assoc (lambdacd/assemble-pipeline pdef config)
+            :name pname))
+   pipeline-defs))
+
+(defrecord Pipelines [pipeline-defs config]
+  component/Lifecycle
+  (start [component]
+    (let [pipelines (assemble-pipelines pipeline-defs config)]
+      (start-pipelines pipelines)
+      (assoc component :pipelines pipelines)))
+  (stop [component]
+    (if-let [pipelines (:pipelines component)]
+      (do (stop-pipelines pipelines)
+          (dissoc component :pipelines))
+      component)))
+
+(defn new-lambdacd-pipeline [pipeline-defs config]
+  (map->Pipelines {:pipeline-defs pipeline-defs
+                   :config config}))

--- a/test/system/components/lambdacd_test.clj
+++ b/test/system/components/lambdacd_test.clj
@@ -1,0 +1,27 @@
+(ns system.components.lambdacd-test
+  (:require [system.components.lambdacd :refer [new-lambdacd-pipeline]]
+            [lambdacd.steps.shell :as shell]
+            [com.stuartsierra.component :as component]
+            [clojure.test :refer [testing deftest is]]))
+
+
+(defn some-step-that-echos-foo [args ctx]
+  (shell/bash ctx "/" "echo foo"))
+
+(defn some-step-that-echos-bar [args ctx]
+  (shell/bash ctx "/" "echo bar"))
+
+(def pipeline-def
+  `(some-step-that-echos-foo
+    some-step-that-echos-bar))
+
+(def pipelines (new-lambdacd-pipeline {:demo pipeline-def}
+                                      {:name "test pipeline"
+                                       :home-dir "/tmp/"}))
+
+(deftest pipeline-lifecycle
+  (alter-var-root #'pipelines component/start)
+  (is (seq? (:pipelines pipelines)) "Pipelines has been added to component")
+  (doseq [pipeline (:pipelines pipelines)]
+    (is (:context pipeline)) "Pipeline should have context")
+  (alter-var-root #'pipelines component/stop))


### PR DESCRIPTION
The [lambdacd](https://github.com/flosell/lambdacd) component takes a map of pipelines, the key of map is
passed as name to the assembled pipeline which can be
referenced later to identify the pipeline.

Usage example https://github.com/shakdwipeea/airplanes

Based on https://github.com/flosell/lambdacd/issues/153 