### PR TITLE
Fix with-cider option in repl server

### DIFF
--- a/src/system/components/repl_server.clj
+++ b/src/system/components/repl_server.clj
@@ -9,7 +9,7 @@
                            (resolve 'clojure.tools.nrepl.server/start-server))
           nrepl-handler #(do (require 'cider.nrepl)
                              (ns-resolve 'cider.nrepl 'cider-nrepl-handler))
-          handler (when with-cider (nrepl-handler))]
+          handler (when with-cider nrepl-handler)]
       (assoc component :server (start-server :port port :bind bind :handler handler))))
   (stop [{server :server :as component}]
     (when server


### PR DESCRIPTION
The `nrepl-handler` function call on line repl_server.clj:12 would fail when called without the arguments, that call is not needed and `nrepl-handler` should be passed to `start-server` directly.